### PR TITLE
feat: change a global variable to a local variable for thread-safe resolution

### DIFF
--- a/pkg/crypto/primitive/bbs12381g2pub/bbs.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/bbs.go
@@ -7,7 +7,7 @@ SPDX-License-Identifier: Apache-2.0
 // Package bbs12381g2pub contains BBS+ signing primitives and keys. Although it can be used directly, it is recommended
 // to use BBS+ keys created by the kms along with the framework's Crypto service.
 // The default local Crypto service is found at: "github.com/hyperledger/aries-framework-go/pkg/crypto/tinkcrypto"
-//  while the remote Crypto service is found at: "github.com/hyperledger/aries-framework-go/pkg/crypto/webkms"
+// while the remote Crypto service is found at: "github.com/hyperledger/aries-framework-go/pkg/crypto/webkms"
 package bbs12381g2pub
 
 import (
@@ -16,12 +16,6 @@ import (
 	"sort"
 
 	bls12381 "github.com/kilic/bls12-381"
-)
-
-// nolint:gochecknoglobals
-var (
-	g1 = bls12381.NewG1()
-	g2 = bls12381.NewG2()
 )
 
 // BBSG2Pub defines BBS+ signature scheme where public key is a point in the field of G2.
@@ -194,6 +188,7 @@ func (bbs *BBSG2Pub) DeriveProof(messages [][]byte, sigBytes, nonce, pubKeyBytes
 // SignWithKey signs the one or more messages using BBS+ key pair.
 func (bbs *BBSG2Pub) SignWithKey(messages [][]byte, privKey *PrivateKey) ([]byte, error) {
 	var err error
+	g1 := bls12381.NewG1()
 
 	pubKey := privKey.PublicKey()
 	messagesCount := len(messages)
@@ -229,6 +224,7 @@ func (bbs *BBSG2Pub) SignWithKey(messages [][]byte, privKey *PrivateKey) ([]byte
 
 func computeB(s *bls12381.Fr, messages []*SignatureMessage, key *PublicKeyWithGenerators) *bls12381.PointG1 {
 	const basesOffset = 2
+	g1 := bls12381.NewG1()
 
 	cb := newCommitmentBuilder(len(messages) + basesOffset)
 
@@ -264,6 +260,7 @@ func (cb *commitmentBuilder) build() *bls12381.PointG1 {
 }
 
 func sumOfG1Products(bases []*bls12381.PointG1, scalars []*bls12381.Fr) *bls12381.PointG1 {
+	g1 := bls12381.NewG1()
 	res := g1.Zero()
 
 	for i := 0; i < len(bases); i++ {

--- a/pkg/crypto/primitive/bbs12381g2pub/keys.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/keys.go
@@ -84,6 +84,7 @@ func (pk *PublicKey) ToPublicKeyWithGenerators(messagesCount int) (*PublicKeyWit
 }
 
 func calcData(key *PublicKey, messagesCount int) []byte {
+	g2 := bls12381.NewG2()
 	data := g2.ToUncompressed(key.PointG2)
 
 	data = append(data, 0, 0, 0, 0, 0, 0)
@@ -96,6 +97,7 @@ func calcData(key *PublicKey, messagesCount int) []byte {
 }
 
 func hashToG1(data []byte) (*bls12381.PointG1, error) {
+	g1 := bls12381.NewG1()
 	dstG1 := []byte("BLS12381G1_XMD:BLAKE2B_SSWU_RO_BBS+_SIGNATURES:1_0_0")
 
 	hashFunc := func() hash.Hash {
@@ -135,6 +137,7 @@ func (k *PrivateKey) Marshal() ([]byte, error) {
 
 // PublicKey returns a Public Key as G2 point generated from the Private Key.
 func (k *PrivateKey) PublicKey() *PublicKey {
+	g2 := bls12381.NewG2()
 	pointG2 := g2.One()
 	g2.MulScalar(pointG2, pointG2, frToRepr(k.FR))
 
@@ -143,6 +146,7 @@ func (k *PrivateKey) PublicKey() *PublicKey {
 
 // UnmarshalPublicKey parses a PublicKey from bytes.
 func UnmarshalPublicKey(pubKeyBytes []byte) (*PublicKey, error) {
+	g2 := bls12381.NewG2()
 	if len(pubKeyBytes) != bls12381G2PublicKeyLen {
 		return nil, errors.New("invalid size of public key")
 	}
@@ -159,6 +163,7 @@ func UnmarshalPublicKey(pubKeyBytes []byte) (*PublicKey, error) {
 
 // Marshal marshals PublicKey.
 func (pk *PublicKey) Marshal() ([]byte, error) {
+	g2 := bls12381.NewG2()
 	pkBytes := g2.ToCompressed(pk.PointG2)
 
 	return pkBytes, nil

--- a/pkg/crypto/primitive/bbs12381g2pub/proof_of_knowledge.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/proof_of_knowledge.go
@@ -30,6 +30,7 @@ type PoKOfSignature struct {
 // NewPoKOfSignature creates a new PoKOfSignature.
 func NewPoKOfSignature(signature *Signature, messages []*SignatureMessage, revealedIndexes []int,
 	pubKey *PublicKeyWithGenerators) (*PoKOfSignature, error) {
+	g1 := bls12381.NewG1()
 	err := signature.Verify(messages, pubKey)
 	if err != nil {
 		return nil, fmt.Errorf("verify input signature: %w", err)
@@ -149,6 +150,7 @@ func newVC2Signature(d *bls12381.PointG1, r3 *bls12381.Fr, pubKey *PublicKeyWith
 
 // ToBytes converts PoKOfSignature to bytes.
 func (pos *PoKOfSignature) ToBytes() []byte {
+	g1 := bls12381.NewG1()
 	challengeBytes := g1.ToUncompressed(pos.aBar)
 	challengeBytes = append(challengeBytes, pos.pokVC1.ToBytes()...)
 	challengeBytes = append(challengeBytes, pos.pokVC2.ToBytes()...)
@@ -176,6 +178,7 @@ type ProverCommittedG1 struct {
 
 // ToBytes converts ProverCommittedG1 to bytes.
 func (g *ProverCommittedG1) ToBytes() []byte {
+	g1 := bls12381.NewG1()
 	bytes := make([]byte, 0)
 
 	for _, base := range g.bases {

--- a/pkg/crypto/primitive/bbs12381g2pub/signature.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/signature.go
@@ -25,6 +25,7 @@ func ParseSignature(sigBytes []byte) (*Signature, error) {
 	if len(sigBytes) != bls12381SignatureLen {
 		return nil, errors.New("invalid size of signature")
 	}
+	g1 := bls12381.NewG1()
 
 	pointG1, err := g1.FromCompressed(sigBytes[:g1CompressedSize])
 	if err != nil {
@@ -43,6 +44,7 @@ func ParseSignature(sigBytes []byte) (*Signature, error) {
 
 // ToBytes converts signature to bytes using compression of G1 point and E, S FR points.
 func (s *Signature) ToBytes() ([]byte, error) {
+	g1 := bls12381.NewG1()
 	bytes := make([]byte, bls12381SignatureLen)
 
 	copy(bytes, g1.ToCompressed(s.A))
@@ -55,6 +57,8 @@ func (s *Signature) ToBytes() ([]byte, error) {
 // Verify is used for signature verification.
 func (s *Signature) Verify(messages []*SignatureMessage, pubKey *PublicKeyWithGenerators) error {
 	p1 := s.A
+	g1 := bls12381.NewG1()
+	g2 := bls12381.NewG2()
 
 	q1 := g2.One()
 	g2.MulScalar(q1, q1, frToRepr(s.E))

--- a/pkg/crypto/primitive/bbs12381g2pub/signature_proof.go
+++ b/pkg/crypto/primitive/bbs12381g2pub/signature_proof.go
@@ -28,6 +28,7 @@ type PoKOfSignatureProof struct {
 // GetBytesForChallenge creates bytes for proof challenge.
 func (sp *PoKOfSignatureProof) GetBytesForChallenge(revealedMessages map[int]*SignatureMessage,
 	pubKey *PublicKeyWithGenerators) []byte {
+	g1 := bls12381.NewG1()
 	hiddenCount := pubKey.messagesCount - len(revealedMessages)
 
 	bytesLen := (7 + hiddenCount) * g1UncompressedSize //nolint:gomnd
@@ -54,6 +55,8 @@ func (sp *PoKOfSignatureProof) GetBytesForChallenge(revealedMessages map[int]*Si
 // Verify verifies PoKOfSignatureProof.
 func (sp *PoKOfSignatureProof) Verify(challenge *bls12381.Fr, pubKey *PublicKeyWithGenerators,
 	revealedMessages map[int]*SignatureMessage, messages []*SignatureMessage) error {
+	g1 := bls12381.NewG1()
+	g2 := bls12381.NewG2()
 	aBar := new(bls12381.PointG1)
 	g1.Neg(aBar, sp.aBar)
 
@@ -71,6 +74,7 @@ func (sp *PoKOfSignatureProof) Verify(challenge *bls12381.Fr, pubKey *PublicKeyW
 }
 
 func (sp *PoKOfSignatureProof) verifyVC1Proof(challenge *bls12381.Fr, pubKey *PublicKeyWithGenerators) error {
+	g1 := bls12381.NewG1()
 	basesVC1 := []*bls12381.PointG1{sp.aPrime, pubKey.h0}
 	aBarD := new(bls12381.PointG1)
 	g1.Sub(aBarD, sp.aBar, sp.d)
@@ -85,6 +89,7 @@ func (sp *PoKOfSignatureProof) verifyVC1Proof(challenge *bls12381.Fr, pubKey *Pu
 
 func (sp *PoKOfSignatureProof) verifyVC2Proof(challenge *bls12381.Fr, pubKey *PublicKeyWithGenerators,
 	revealedMessages map[int]*SignatureMessage, messages []*SignatureMessage) error {
+	g1 := bls12381.NewG1()
 	revealedMessagesCount := len(revealedMessages)
 
 	basesVC2 := make([]*bls12381.PointG1, 0, 2+pubKey.messagesCount-revealedMessagesCount)
@@ -131,6 +136,7 @@ func (sp *PoKOfSignatureProof) verifyVC2Proof(challenge *bls12381.Fr, pubKey *Pu
 
 // ToBytes converts PoKOfSignatureProof to bytes.
 func (sp *PoKOfSignatureProof) ToBytes() []byte {
+	g1 := bls12381.NewG1()
 	bytes := make([]byte, 0)
 
 	bytes = append(bytes, g1.ToCompressed(sp.aPrime)...)
@@ -164,6 +170,7 @@ func NewProofG1(commitment *bls12381.PointG1, responses []*bls12381.Fr) *ProofG1
 
 // Verify verifies the ProofG1.
 func (pg1 *ProofG1) Verify(bases []*bls12381.PointG1, commitment *bls12381.PointG1, challenge *bls12381.Fr) error {
+	g1 := bls12381.NewG1()
 	contribution := pg1.getChallengeContribution(bases, commitment, challenge)
 	g1.Sub(contribution, contribution, pg1.commitment)
 
@@ -184,6 +191,7 @@ func (pg1 *ProofG1) getChallengeContribution(bases []*bls12381.PointG1, commitme
 
 // ToBytes converts ProofG1 to bytes.
 func (pg1 *ProofG1) ToBytes() []byte {
+	g1 := bls12381.NewG1()
 	bytes := make([]byte, 0)
 
 	commitmentBytes := g1.ToCompressed(pg1.commitment)
@@ -209,6 +217,7 @@ func ParseSignatureProof(sigProofBytes []byte) (*PoKOfSignatureProof, error) {
 
 	g1Points := make([]*bls12381.PointG1, 3)
 	offset := 0
+	g1 := bls12381.NewG1()
 
 	for i := range g1Points {
 		g1Point, err := g1.FromCompressed(sigProofBytes[offset : offset+g1CompressedSize])
@@ -251,6 +260,7 @@ func ParseProofG1(bytes []byte) (*ProofG1, error) {
 	}
 
 	offset := 0
+	g1 := bls12381.NewG1()
 
 	commitment, err := g1.FromCompressed(bytes[:g1CompressedSize])
 	if err != nil {


### PR DESCRIPTION
There is a thread-safe issue when using the BBS algorithm provided by `aries-framework-go`.
The cause is a global variable declared here.(https://github.com/hyperledger/aries-framework-go/blob/main/pkg/crypto/primitive/bbs12381g2pub/bbs.go#L23)

I changed the global variable to a local variable.(Thanks @youngjoon-lee )